### PR TITLE
Refactor: Simplify autoUpdate API in useFloating

### DIFF
--- a/docs/api/use-floating.md
+++ b/docs/api/use-floating.md
@@ -125,7 +125,7 @@ Options for configuring the behavior of the `useFloating` composable.
 | `strategy`             | `MaybeRefOrGetter<Strategy>`                                  | Positioning strategy: `'absolute'` or `'fixed'`.                                                                                     |
 | `transform`            | `MaybeRefOrGetter<boolean>`                                   | Whether to use CSS `transform` for positioning (improves performance).                                                               |
 | `middlewares`          | `Middleware[]`                                                | An array of middleware functions to apply to the positioning.                                                                        |
-| `whileElementsMounted` | `(anchorEl: ..., floatingEl: ..., update: ...) => () => void` | Function called when elements are mounted, useful for setting up auto-update. Returns a cleanup function.                            |
+| `autoUpdate`           | `boolean \| AutoUpdateOptions`                                | Whether to automatically update the position of the floating element. Can be a boolean or an `AutoUpdateOptions` object. Defaults to `true`. |
 | `open`                 | `Ref<boolean>`                                                | A reactive boolean to control the open/closed state of the floating element.                                                         |
 | `setOpen`              | `(open: boolean) => void`                                     | Function to control the open state of the floating element. If not provided, a default function is used that updates the `open` ref. |
 
@@ -177,4 +177,4 @@ An interface for the computed CSS styles object that positions the floating elem
 
 1. **Use CSS transforms**: Keep `transform: true` (default) for better performance
 2. **Minimize middleware**: Only use necessary middleware to reduce computation
-3. **Custom auto-update**: Implement custom `whileElementsMounted` for specific use cases
+3. **Customize auto-update**: Use the `autoUpdate` option to control when and how position updates occur. For specific use cases, you can provide an `AutoUpdateOptions` object to fine-tune the behavior.

--- a/src/composables/use-floating.ts
+++ b/src/composables/use-floating.ts
@@ -86,13 +86,11 @@ export interface UseFloatingOptions {
   middlewares?: Middleware[]
 
   /**
-   * Function called when both the anchor and floating elements are mounted.
+   * Whether to automatically update the position of the floating element.
+   * Can be a boolean or an `AutoUpdateOptions` object.
+   * @default true
    */
-  whileElementsMounted?: (
-    anchorEl: NonNullable<AnchorElement>,
-    floatingEl: NonNullable<FloatingElement>,
-    update: () => void
-  ) => undefined | (() => void)
+  autoUpdate?: boolean | AutoUpdateOptions
 
   /**
    * Whether the floating element is open.
@@ -201,7 +199,7 @@ export function useFloating(
   const {
     transform = true,
     middlewares,
-    whileElementsMounted,
+    autoUpdate: autoUpdateOptions = true,
     open = ref(false),
     setOpen = (value: boolean) => {
       open.value = value
@@ -250,10 +248,13 @@ export function useFloating(
     ([anchorEl, floatingEl, open]) => {
       if (!open || !anchorEl || !floatingEl) return
 
-      if (whileElementsMounted) {
-        cleanup = whileElementsMounted(anchorEl, floatingEl, update)
-      } else {
-        cleanup = floatingUIAutoUpdate(anchorEl, floatingEl, update)
+      if (autoUpdateOptions) {
+        cleanup = floatingUIAutoUpdate(
+          anchorEl,
+          floatingEl,
+          update,
+          typeof autoUpdateOptions === "object" ? autoUpdateOptions : undefined
+        )
       }
 
       onWatcherCleanup(() => {
@@ -349,25 +350,4 @@ function getDPR(el: HTMLElement) {
   if (typeof window === "undefined") return 1
   const win = el.ownerDocument.defaultView || window
   return win.devicePixelRatio || 1
-}
-
-/**
- * Auto-update function to use with `whileElementsMounted` option
- *
- * This function provides automatic position updates for floating elements.
- * It's a wrapper around Floating UI's autoUpdate function.
- *
- * @param anchorEl - The anchor element
- * @param floatingEl - The floating element
- * @param update - The update function to call
- * @param options - Additional options for auto-updating
- * @returns A cleanup function to stop auto-updating
- */
-export function autoUpdate(
-  anchorEl: HTMLElement,
-  floatingEl: HTMLElement,
-  update: () => void,
-  options: AutoUpdateOptions = {}
-) {
-  return floatingUIAutoUpdate(anchorEl, floatingEl, update, options)
 }


### PR DESCRIPTION
Removes the `whileElementsMounted` option and the exported `autoUpdate` helper function from the `useFloating` composable.

Introduces a new `autoUpdate` option that accepts a boolean or an `AutoUpdateOptions` object, aligning the API more closely with `@floating-ui/dom`.

Updates documentation and tests to reflect these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to replace the deprecated `whileElementsMounted` option with the new `autoUpdate` option, including revised best practices.

* **New Features**
  * Introduced an `autoUpdate` option for controlling automatic position updates of floating elements.

* **Refactor**
  * Replaced the `whileElementsMounted` option with `autoUpdate` in the floating element composable and updated related logic.

* **Tests**
  * Refactored tests to verify behavior using the new `autoUpdate` option and improved test coverage for related scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->