### PR TITLE
Fix: Align API docs with source code for several composables

### DIFF
--- a/docs/api/flip.md
+++ b/docs/api/flip.md
@@ -22,7 +22,7 @@ const { x, y, strategy } = useFloating({
 ```ts
 interface FlipOptions {
   mainAxis?: boolean
-  crossAxis?: boolean
+  crossAxis?: boolean | 'alignment'
   fallbackAxisSideDirection?: 'none' | 'start' | 'end'
   flipAlignment?: boolean
   fallbackPlacements?: Array<Placement>

--- a/docs/api/shift.md
+++ b/docs/api/shift.md
@@ -24,7 +24,9 @@ interface ShiftOptions {
   mainAxis?: boolean
   crossAxis?: boolean
   limiter?: {
-    fn: (state: { x: number, y: number }) => { x: number, y: number }
+    // state: MiddlewareState from @floating-ui/dom
+    // returns: Coords from @floating-ui/dom ({ x: number, y: number })
+    fn: (state: any) => { x: number, y: number }
     options?: any
   }
 }

--- a/docs/api/size.md
+++ b/docs/api/size.md
@@ -28,17 +28,20 @@ const { x, y, strategy } = useFloating({
 ## Options
 
 ```ts
+// SizeOptions extends DetectOverflowOptions from @floating-ui/core
 interface SizeOptions {
-  apply: (state: {
+  // apply's state combines MiddlewareState with availableWidth and availableHeight
+  apply?: (state: {
     availableWidth: number
     availableHeight: number
     elements: {
-      floating: HTMLElement
-      reference: HTMLElement
+      floating: HTMLElement // HTMLElement from @floating-ui/dom
+      reference: Element | VirtualElement // Element | VirtualElement from @floating-ui/dom
     }
-  }) => void
-  padding?: number | Partial<Record<string, number>>
-  boundary?: 'clippingAncestors' | Element | Array<Element>
-  rootBoundary?: 'document' | 'viewport'
+    // ... other MiddlewareState properties like rects, placement, strategy are also available
+  } & any) => void // Using 'any' to represent MiddlewareState for brevity
+  padding?: number | Partial<Record<string, number>> // From DetectOverflowOptions
+  boundary?: 'clippingAncestors' | Element | Array<Element> // From DetectOverflowOptions
+  rootBoundary?: 'document' | 'viewport' // From DetectOverflowOptions
 }
 ```

--- a/docs/api/use-client-point.md
+++ b/docs/api/use-client-point.md
@@ -1,52 +1,176 @@
 # useClientPoint
 
-A composable that enables tracking of client point (mouse/touch) coordinates for floating elements.
+The `useClientPoint` composable configures a floating element (managed by `useFloating`) to position itself relative to the client's pointer (e.g., mouse cursor or touch point). It achieves this by dynamically updating the `anchorEl` within the `FloatingContext` to a virtual element that represents the pointer's current coordinates. This allows the floating element to "follow" the pointer.
 
-## Usage
+## Usage Example
+
+Here's how to use `useClientPoint` in conjunction with `useFloating`:
 
 ```vue
-<script setup>
-import { useClientPoint } from 'vfloat'
+<script setup lang="ts">
+import { ref } from 'vue';
+import { useFloating, useClientPoint } from 'vfloat'; // Ensure correct import path
 
-const { refs, x, y } = useClientPoint()
+// Ref for the DOM element that pointer events will be listened on
+const pointerTargetRef = ref<HTMLElement | null>(null);
+// Ref for the DOM element that will float
+const floatingElRef = ref<HTMLElement | null>(null);
+// Controls the visibility of the floating element
+const isOpen = ref(false);
+
+// 1. Initialize useFloating.
+// The `referenceRef` for useFloating can initially be the pointerTargetRef.
+// useClientPoint will later override `context.refs.anchorEl` with a virtual element.
+const { floatingStyles, context: floatingContext } = useFloating(
+  pointerTargetRef, // Initial reference, will be effectively replaced by virtual element
+  floatingElRef,
+  {
+    placement: 'bottom-start', // This will be relative to the client point
+    open: isOpen,
+    // `whileElementsMounted: autoUpdate` could be added if updates on scroll/resize are needed
+    // while the pointer isn't moving.
+  }
+);
+
+// 2. Initialize useClientPoint.
+// It takes the pointerTargetRef (to listen for mouse/touch events) and the
+// floatingContext (to update its anchorEl).
+const clientPoint = useClientPoint(pointerTargetRef, floatingContext, {
+  enabled: isOpen, // Only track and update when the floating element is open
+  axis: 'both',    // The virtual element follows both x and y pointer axes
+});
+
+function handlePointerEnter() {
+  isOpen.value = true;
+}
+
+function handlePointerLeave() {
+  isOpen.value = false;
+}
 </script>
 
 <template>
-  <div ref="refs.setReference">
-    Hover me
-  </div>
   <div
-    v-if="x && y"
-    :style="{
-      position: 'absolute',
-      left: `${x}px`,
-      top: `${y}px`,
-    }"
+    ref="pointerTargetRef"
+    class="pointer-target-area"
+    @pointerenter="handlePointerEnter"
+    @pointerleave="handlePointerLeave"
   >
-    I follow the cursor!
+    Hover over this area to see the floating element.
+    <div v-if="isOpen" style="font-size: 0.8em; margin-top: 5px;">
+      (Raw ClientX: {{ clientPoint.coordinates.value.x }}, ClientY: {{ clientPoint.coordinates.value.y }})
+    </div>
+  </div>
+
+  <div
+    v-if="isOpen"
+    ref="floatingElRef"
+    class="floating-tooltip"
+    :style="floatingStyles"
+  >
+    Tooltip following pointer
   </div>
 </template>
+
+<style scoped>
+.pointer-target-area {
+  width: 300px;
+  height: 150px;
+  background-color: #f0f0f0;
+  border: 1px solid #ccc;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+.floating-tooltip {
+  background-color: #333;
+  color: white;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 0.9em;
+  pointer-events: none; /* Important for tooltips that follow the cursor */
+  /* Ensure z-index if it might be overlapped */
+  z-index: 1000;
+}
+</style>
 ```
 
-## API
+### Explanation:
 
-### Options
+1.  **`pointerTargetRef`**: This is a Vue ref attached to the DOM element where you want to detect pointer movements (e.g., a div, a button).
+2.  **`floatingElRef`**: This is a Vue ref for the actual element that will appear and float.
+3.  **`useFloating`**: Initialize `useFloating` as usual. You can pass `pointerTargetRef` as its initial `referenceEl`. The `placement` option will determine how the `floatingElRef` is positioned relative to the (eventual) client point.
+4.  **`useClientPoint`**:
+    *   Pass `pointerTargetRef` to it, so it knows which element's pointer events to track.
+    *   Pass the `context` from `useFloating`. `useClientPoint` uses this to set `context.refs.anchorEl` to a new [Virtual Element](https://floating-ui.com/docs/virtual-elements). This virtual element's `getBoundingClientRect` will return the current pointer coordinates.
+    *   `useFloating` automatically reacts to changes in `context.refs.anchorEl` and re-positions `floatingElRef` based on the virtual element's position.
+5.  **Styling**: Apply the `floatingStyles` from `useFloating` to your `floatingElRef` to position it.
+6.  **`clientPoint.coordinates`**: The return from `useClientPoint` includes `coordinates` which is a `Ref` to an object `{ x, y }` representing the raw client coordinates. This is mostly for informational purposes or if you need to react to the raw pointer data directly. The positioning of the floating element itself is handled via `useFloating` and its `floatingStyles`.
+
+This setup allows the `floating-tooltip` to follow the mouse/touch pointer when it's over the `pointer-target-area`.
+
+## API Reference
+
+The `useClientPoint` composable positions a floating element relative to the client's pointer (mouse/touch) position. It works by updating the `anchorEl` of a `FloatingContext` to a virtual element representing the pointer's coordinates.
+
+### Function Signature
 
 ```ts
+import type { Ref } from 'vue';
+import type { FloatingContext } from 'vfloat'; // Or actual path
+import type { MaybeRefOrGetter } from 'vue'; // Or from '@vueuse/core'
+
 interface UseClientPointOptions {
-  enabled?: boolean
-  axis?: 'both' | 'x' | 'y'
+  enabled?: MaybeRefOrGetter<boolean>;
+  axis?: MaybeRefOrGetter<'x' | 'y' | 'both'>;
+  x?: MaybeRefOrGetter<number | null>; // Controlled external x coordinate
+  y?: MaybeRefOrGetter<number | null>; // Controlled external y coordinate
 }
-```
 
-### Returns
-
-```ts
 interface UseClientPointReturn {
-  x: Ref<number | null>
-  y: Ref<number | null>
-  refs: {
-    setReference: (el: Element | null) => void
-  }
+  coordinates: Readonly<Ref<{ x: number | null; y: number | null }>>;
+  updatePosition: (x: number, y: number) => void;
 }
+
+function useClientPoint(
+  pointerTarget: Ref<HTMLElement | null>, // The element to attach pointer listeners to
+  context: FloatingContext,             // The context from useFloating
+  options?: UseClientPointOptions
+): UseClientPointReturn;
 ```
+
+### Parameters
+
+1.  **`pointerTarget: Ref<HTMLElement | null>`**
+    *   A Vue Ref to the DOM element that will serve as the target for pointer event listeners (e.g., `pointermove`, `pointerenter`). The floating element's position will be relative to pointer events within this element.
+
+2.  **`context: FloatingContext`**
+    *   The `FloatingContext` object obtained from `useFloating`. `useClientPoint` will update `context.refs.anchorEl` with a virtual element representing the pointer's current position. `useFloating` will then use this virtual element to position the actual floating DOM element.
+
+3.  **`options?: UseClientPointOptions`** (optional)
+    *   An optional configuration object.
+
+### Options (`UseClientPointOptions`)
+
+| Option    | Type                                     | Default   | Description                                                                                                |
+| --------- | ---------------------------------------- | --------- | ---------------------------------------------------------------------------------------------------------- |
+| `enabled` | `MaybeRefOrGetter<boolean>`              | `true`    | Whether the client point tracking is enabled.                                                              |
+| `axis`    | `MaybeRefOrGetter<'x' \| 'y' \| 'both'>`   | `'both'`  | Specifies which axis/axes the virtual element should follow. `'x'`, `'y'`, or `'both'`.                      |
+| `x`       | `MaybeRefOrGetter<number \| null>`       | `null`    | A controlled x-coordinate. If provided, the internal pointer tracking for x is overridden.                 |
+| `y`       | `MaybeRefOrGetter<number \| null>`       | `null`    | A controlled y-coordinate. If provided, the internal pointer tracking for y is overridden.                 |
+
+(Note: `MaybeRefOrGetter<T>` implies the value can be `T`, `Ref<T>`, or `() => T`.)
+
+### Return Value (`UseClientPointReturn`)
+
+An object with the following properties:
+
+*   **`coordinates: Readonly<Ref<{ x: number | null; y: number | null }>>`**:
+    A readonly ref containing the current client (pointer) coordinates (`{ x, y }`) that `useClientPoint` is tracking or has been set to. This is useful for debugging or displaying the raw pointer position.
+
+*   **`updatePosition: (x: number, y: number) => void`**:
+    A function to manually update the client point coordinates that `useClientPoint` uses to position the virtual element. This can be used to programmatically move the floating element as if the pointer moved.


### PR DESCRIPTION
This commit brings the API documentation for several files in `docs/api` into closer alignment with their corresponding source code implementations in `src`.

Key changes include:

- `docs/api/flip.md`: Corrected the type of the `crossAxis` option in `FlipOptions`.
- `docs/api/shift.md`: Updated the type signature for `limiter.fn` within `ShiftOptions` to more accurately reflect the expected parameters from `@floating-ui/dom`.
- `docs/api/size.md`: Made the `apply` method in `SizeOptions` optional and refined the type of its `state` parameter, including correcting `elements.reference` to accept `Element | VirtualElement`.
- `docs/api/use-arrow.md`:
    - Renamed `arrowMiddleware` to `arrow` to match the actual export.
    - Corrected the function signature, options (`ArrowMiddlewareOptions`), and parameter types (e.g., `element` is `Ref<HTMLElement | null>`, `padding` is optional) for the `arrow` middleware.
    - Corrected the function signature, options (`UseArrowOptions`), and return type (`UseArrowReturn`) for the `useArrow` composable.
    - Updated all examples to use the correct function names, signatures, and import paths.
- `docs/api/use-click.md`:
    - Corrected the return type of `useClick` from prop getters to `void`, as it directly attaches event listeners.
    - Updated `UseClickOptions` to match source (e.g., `event` type, reactive option types).
    - Rewrote all examples to remove references to a non-existent `useInteractions` composable and `getReferenceProps` pattern for `useClick`. Examples now reflect direct event listener attachment by `useClick` and manual ARIA attribute application where necessary.
- `docs/api/use-client-point.md`:
    - Corrected the function signature of `useClientPoint` to include `pointerTarget` and `context` parameters.
    - Updated `UseClientPointOptions` to include `x` and `y` for controlled coordinates and specify `MaybeRefOrGetter` for reactive options.
    - Corrected `UseClientPointReturn` to reflect the actual return structure (`coordinates` object, `updatePosition` function) and remove non-existent `refs.setReference`.
    - Completely rewrote the usage example to demonstrate the correct integration with `useFloating` and `FloatingContext`.

A recurring theme in these corrections, particularly for interaction hooks like `useClick` and `useClientPoint`, was the removal of a `useInteractions` pattern and prop-getters. The source code indicates these hooks operate by directly attaching listeners or modifying context, rather than returning props to be spread by a higher-level interactions manager (which doesn't appear to exist in the current `v-float` source).

Further work is needed on remaining `docs/api` files, and these may exhibit similar discrepancies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified API documentation for multiple composables and middleware, including `useClientPoint`, `useClick`, `useArrow`, and floating UI middleware options.
  * Updated usage examples, API references, and type annotations for improved clarity and accuracy.
  * Revised example code snippets to reflect new usage patterns and function signatures.
  * Enhanced explanations and added detailed tables for options and return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->